### PR TITLE
How to check my code

### DIFF
--- a/lib/screens/modules/time_tracker/logs_list.dart
+++ b/lib/screens/modules/time_tracker/logs_list.dart
@@ -380,7 +380,7 @@ Future<void> _showEditExpensesPopup() async {
   final bool perDiemUsedElsewhere = widget.perDiemLogId != null && widget.perDiemLogId != widget.logId;
   final bool perDiemAvailableHere = widget.perDiemLogId == null || widget.perDiemLogId == widget.logId;
 
-  await showDialog(
+  final result = await showDialog<Map<String, dynamic>>(
     context: context,
     barrierDismissible: true,            // Allow tap-away to close
     useRootNavigator: true,              // Always use root navigator
@@ -552,7 +552,7 @@ Future<void> _showEditExpensesPopup() async {
             actions: [
               TextButton(
                 onPressed: () {
-                  Navigator.of(dialogCtx).pop();  // Always close with correct dialogCtx
+                  Navigator.of(dialogCtx).pop(null);  // Return null on cancel
                 },
                 child: Text('Cancel', style: TextStyle(color: primaryColor, fontSize: 16)),
               ),
@@ -565,10 +565,7 @@ Future<void> _showEditExpensesPopup() async {
                   textStyle: const TextStyle(fontWeight: FontWeight.bold, fontSize: 16),
                 ),
                 onPressed: () {
-                  setState(() {
-                    expenses = Map<String, dynamic>.from(tempExpenses);
-                  });
-                  Navigator.of(dialogCtx).pop(); // Always close with correct dialogCtx
+                  Navigator.of(dialogCtx).pop(Map<String, dynamic>.from(tempExpenses));
                 },
                 child: const Text('Save'),
               ),
@@ -578,6 +575,13 @@ Future<void> _showEditExpensesPopup() async {
       );
     },
   );
+  
+  if (!mounted) return;
+  if (result != null) {
+    setState(() {
+      expenses = result;
+    });
+  }
 }
 
 

--- a/lib/screens/modules/time_tracker/time_entry_card.dart
+++ b/lib/screens/modules/time_tracker/time_entry_card.dart
@@ -137,9 +137,9 @@ class _TimeEntryCardState extends State<TimeEntryCard>
 
     await showDialog(
       context: context,
-      useRootNavigator: false,
+      useRootNavigator: true,
       barrierDismissible: false,
-      builder: (_) => StatefulBuilder(
+      builder: (dialogCtx) => StatefulBuilder(
         builder: (context, setStateDialog) {
           bool canAddExpense() {
             final name = nameCtrl.text.trim();
@@ -308,7 +308,7 @@ class _TimeEntryCardState extends State<TimeEntryCard>
             actionsPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
             actions: [
               TextButton(
-                onPressed: () => Navigator.pop(context),
+                onPressed: () => Navigator.of(dialogCtx).pop(),
                 child: Text('Cancel', style: TextStyle(color: primaryColor, fontSize: 16)),
               ),
               ElevatedButton(
@@ -323,7 +323,7 @@ class _TimeEntryCardState extends State<TimeEntryCard>
                   setState(() {
                     _expenses = Map<String, dynamic>.from(tempExpenses);
                   });
-                  Navigator.pop(context);
+                  Navigator.of(dialogCtx).pop();
                 },
                 child: const Text('Save'),
               ),

--- a/lib/screens/modules/time_tracker/time_entry_card.dart
+++ b/lib/screens/modules/time_tracker/time_entry_card.dart
@@ -137,9 +137,9 @@ class _TimeEntryCardState extends State<TimeEntryCard>
 
     await showDialog(
       context: context,
-      useRootNavigator: true,
+      useRootNavigator: false,
       barrierDismissible: false,
-      builder: (dialogCtx) => StatefulBuilder(
+      builder: (_) => StatefulBuilder(
         builder: (context, setStateDialog) {
           bool canAddExpense() {
             final name = nameCtrl.text.trim();
@@ -308,7 +308,7 @@ class _TimeEntryCardState extends State<TimeEntryCard>
             actionsPadding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
             actions: [
               TextButton(
-                onPressed: () => Navigator.of(dialogCtx).pop(),
+                onPressed: () => Navigator.pop(context),
                 child: Text('Cancel', style: TextStyle(color: primaryColor, fontSize: 16)),
               ),
               ElevatedButton(
@@ -323,7 +323,7 @@ class _TimeEntryCardState extends State<TimeEntryCard>
                   setState(() {
                     _expenses = Map<String, dynamic>.from(tempExpenses);
                   });
-                  Navigator.of(dialogCtx).pop();
+                  Navigator.pop(context);
                 },
                 child: const Text('Save'),
               ),


### PR DESCRIPTION
Fixes Android issue where edit screen closes when saving expenses in log sessions.

Previously, the expense popup called `setState` inside the dialog, causing navigation stack confusion on Android and closing both the dialog and the parent edit screen. This fix changes the dialog to return the updated expense data, and the parent screen now updates its state *after* the dialog closes, resolving the unexpected closure.